### PR TITLE
Bump crystal to 0.24.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ authors:
 
 license: MIT
 
-crystal: 0.23.1
+crystal: 0.24.1
 
 dependencies:
   stdio:

--- a/src/have_files.cr
+++ b/src/have_files.cr
@@ -21,7 +21,7 @@ module HaveFiles
   def self.rm_r(path)
     if Dir.exists?(path) && !File.symlink?(path)
       Dir.open(path) do |dir|
-        dir.each do |entry|
+        dir.each_entry do |entry|
           if entry != "." && entry != ".."
             src = File.join(path, entry)
             rm_r(src)


### PR DESCRIPTION
Small changes to make it compatible with crystal 0.24.1 given that this shard is required by `cli` that I'm bumping to 0.24.1 as well. Hope you find it useful.

regards